### PR TITLE
Use more tolerant defaults for timeout and retries

### DIFF
--- a/resources/roles_edit.html
+++ b/resources/roles_edit.html
@@ -95,8 +95,8 @@
         <td>
           <input type="text" class="expected-status-code" name="checks[none][expected_status_code]" value="200"/>
         </td>
-        <td><input type="text" class="timeout" name="checks[none][timeout]" value="3"/></td>
-        <td><input type="text" class="max-retries" name="checks[none][max_retries]" value="0"/></td>
+        <td><input type="text" class="timeout" name="checks[none][timeout]" value="10.0"/></td>
+        <td><input type="text" class="max-retries" name="checks[none][max_retries]" value="3"/></td>
         <td class="check-send-email">
           <input type="checkbox" class="send-email" name="checks[none][send_email]" value="true" checked="true"/>
         </td>


### PR DESCRIPTION
These defaults are more tolerant of occasional transient network problems.
